### PR TITLE
XIVY-6566 disable endpoint.cache: as we modify assertion properties

### DIFF
--- a/connectivity/connectivity-demos-test/config/webservice-clients.yaml
+++ b/connectivity/connectivity-demos-test/config/webservice-clients.yaml
@@ -12,6 +12,8 @@ WebServiceClients:
     WsdlUrl: http://test-webservices.ivyteam.io:8080/country-service/webservices/greet-policy-wss?wsdl
     WsCallLibrary: CXF
     ServiceClass: ch.ivyteam.testservice.policy.greeter.client.SecureGreetPolicyServiceService
+    Properties:
+      endpoint.cache: 'false'
     Endpoints:
       SecureGreetPolicyServicePort:
       - http://test-webservices.ivyteam.io:8080/country-service/webservices/greet-policy-wss


### PR DESCRIPTION
- policy setup should be done once per client: here we switch it for
tests ... so the cache won't work.