### PR TITLE
Revert "XIVY-7639 fix: exclude real existing validation problem"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
               recordIssues tools: [eclipse()], unstableTotalAll: 1
               recordIssues tools: [mavenConsole()], unstableTotalAll: 1, filters: [
                 excludeMessage('.*An illegal reflective access operation has occurred.*'), // in rule engine test
-                excludeMessage('processes/soap/service/serviceWithException.mod.*'), // connectivity-demos
               ]
 
               junit testDataPublishers: [[$class: 'StabilityTestDataPublisher']], testResults: '**/target/*-reports/**/*.xml'          


### PR DESCRIPTION
This reverts commit b162cfc471c706139a0ef6e093d6a2b9d0f5860d.

- problem will no longer be exposed by the project-build-plugin