### PR TITLE
adapt to Jackson 2.13

### DIFF
--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/json/OpenApiJsonFeature.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/json/OpenApiJsonFeature.java
@@ -30,6 +30,7 @@ public class OpenApiJsonFeature extends JsonFeature
   public static class JaxRsClientJson extends JacksonJsonProvider
   {
     @Override
+    @SuppressWarnings("deprecation")
     public ObjectMapper locateMapper(Class<?> type, MediaType mediaType)
     {
       ObjectMapper mapper = super.locateMapper(type, mediaType);


### PR DESCRIPTION
- yet we can't use the suggested builder, as we get the objectMapper
from the JAX-RS stack