### PR TITLE
fix2

### DIFF
--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -69,8 +69,8 @@
           <groupId>org.opensaml</groupId>
         </exclusion>
         <exclusion>
-        	<groupId>com.google.guava</groupId>
-        	<artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -80,10 +80,10 @@
       <version>11.1.0</version>
       <scope>test</scope>
       <exclusions>
-      	<exclusion>
-      		<groupId>com.google.guava</groupId>
-      		<artifactId>guava</artifactId>
-      	</exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -68,13 +68,23 @@
           <artifactId>opensaml-xacml-saml-impl</artifactId>
           <groupId>org.opensaml</groupId>
         </exclusion>
+        <exclusion>
+        	<groupId>com.google.guava</groupId>
+        	<artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>com.axonivy.ivy.webtest</groupId>
       <artifactId>web-tester</artifactId>
-      <version>9.3.0</version>
+      <version>11.1.0</version>
       <scope>test</scope>
+      <exclusions>
+      	<exclusion>
+      		<groupId>com.google.guava</groupId>
+      		<artifactId>guava</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -10,6 +10,7 @@
     <wss4j.version>2.4.1</wss4j.version>
     <jersey.version>2.41</jersey.version>
     <project-build-plugin>11.2.0-SNAPSHOT</project-build-plugin>
+    <web.tester.version>11.1.0</web.tester.version>
   </properties>
 
   <pluginRepositories>
@@ -77,7 +78,7 @@
     <dependency>
       <groupId>com.axonivy.ivy.webtest</groupId>
       <artifactId>web-tester</artifactId>
-      <version>11.1.0</version>
+      <version>${web.tester.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/connectivity/connectivity-demos/pom.xml
+++ b/connectivity/connectivity-demos/pom.xml
@@ -63,36 +63,6 @@
           </execution>
         </executions>
       </plugin>
-    </plugins>
-    <pluginManagement>
-      <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <versionRange>[2.8,)</versionRange>
-                    <goals>
-                      <goal>copy-dependencies</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+    </plugins>   
   </build>
-
 </project>


### PR DESCRIPTION
- Use latest web-testr but ommit conflicting guava
- Fix formatting
- Auto-update web-tester for connectivy-demo-test
- Remove legacy m2e lifecycle mapping for maven-dependency-plugin
