### PR TITLE
Use latest commons-lang3 to have no clashes with dep hierarchy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.6-eclipse-temurin-17
+FROM maven:3.9.5-eclipse-temurin-17
 
 # add an user with 1000 for the build in jenkins
 RUN addgroup --gid 1000 build && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" build

--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -93,6 +93,16 @@
       <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- fix this version. because axon ivy engine is using commons.text 1.11.0 which
+        requires commons.lang3 3.13.0. but this maven dependency hierarchy includes an older
+        version -->
+    <dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.13.0</version>
+      <scope>test</scope>
+		</dependency>
   </dependencies>
 
   <build>

--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -98,11 +98,11 @@
         requires commons.lang3 3.13.0. but this maven dependency hierarchy includes an older
         version -->
     <dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.13.0</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.13.0</version>
       <scope>test</scope>
-		</dependency>
+    </dependency>
   </dependencies>
 
   <build>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/opt/bin/start-xvfb.sh & exec "$@"

--- a/workflow/workflow-demos-test/pom.xml
+++ b/workflow/workflow-demos-test/pom.xml
@@ -42,11 +42,11 @@
         requires commons.lang3 3.13.0. but this maven dependency hierarchy includes an older
         version -->
     <dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.13.0</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.13.0</version>
       <scope>test</scope>
-		</dependency>
+    </dependency>
   </dependencies>
 
   <build>

--- a/workflow/workflow-demos-test/pom.xml
+++ b/workflow/workflow-demos-test/pom.xml
@@ -37,6 +37,16 @@
       <version>${web.tester.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- fix this version. because axon ivy engine is using commons.text 1.11.0 which
+        requires commons.lang3 3.13.0. but this maven dependency hierarchy includes an older
+        version -->
+    <dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.13.0</version>
+      <scope>test</scope>
+		</dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
FYI;

- I've upgraded commons-text in core to latest, which requires commons.lang3 latest.
- here we have maven dependencies in test which has an older commons.lang3 version (transitiv)
- result: really strange errors, but only in maven build not by executing test in Axon Ivy Designer

Biggest pain point:
- Maven build behaves different than executing test in Axon Ivy Designer

I've the feeling that this kind of issues will come back to us, if our users are going to write tests.
