### PR TITLE
XIVY-5504 fix signalInvoker used deprecated public API methods

### DIFF
--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/aynch/SignalInvoker.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/aynch/SignalInvoker.java
@@ -42,13 +42,13 @@ public class SignalInvoker implements InvocationCallback<String>
   @Override
   public void completed(String response)
   {
-    asyncRunner.run(() -> Ivy.wf().signals().send(successSignal, response));
+    asyncRunner.run(() -> Ivy.wf().signals().create().data(response).send(successSignal));
   }
 
   @Override
   public void failed(Throwable throwable)
   {
-    asyncRunner.run(() -> Ivy.wf().signals().send(errorSignal, throwable));
+    asyncRunner.run(() -> Ivy.wf().signals().create().data(throwable).send(errorSignal));
   }
 
 }


### PR DESCRIPTION
 signalInvoker used deprecated public API methods

https://github.com/axonivy/core/pull/6787