### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/connectivity/connectivity-demos-product/zip.xml
+++ b/connectivity/connectivity-demos-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/demos-app/demos-app-product/zip.xml
+++ b/demos-app/demos-app-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/error-handling/error-handling-demos-product/zip.xml
+++ b/error-handling/error-handling-demos-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/html-dialog/html-dialog-demos-product/zip.xml
+++ b/html-dialog/html-dialog-demos-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/quick-start-tutorial/quick-start-tutorial-product/zip.xml
+++ b/quick-start-tutorial/quick-start-tutorial-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/rule-engine/rule-engine-demos-product/zip.xml
+++ b/rule-engine/rule-engine-demos-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/workflow/workflow-demos-product/zip.xml
+++ b/workflow/workflow-demos-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml