### PR TITLE
Fix deploy on release branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
               docker.image("selenium/standalone-firefox:4.10").withRun("-e START_XVFB=false --shm-size=2g --name ${seleniumName} --network ${networkName}") {
                 docker.build('maven-selenium').inside("--name ${ivyName} --network ${networkName}") {
                   def workspace = pwd()
-                  def phase = env.BRANCH_NAME == 'master' ? 'deploy' : 'verify'
+                  def phase = isReleasingBranch() ? 'deploy' : 'verify'
                   maven cmd: "clean ${phase} -Dmaven.test.failure.ignore=true  " +
                             "-Dengine.directory=${workspace}/html-dialog-demos/html-dialog-demos/target/ivyEngine " +
                             "-Divy.engine.version.latest.minor=true " +


### PR DESCRIPTION
Any reason why this is like this?
Currently, the demo-projects are only deployed on `master`, `release/8.0` and `release/9.3`...