### PR TITLE
Disable tests on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v4
+    uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v5
     with:
-      mvnArgs: -Dmaven.test.failure.ignore=true
+      mvnArgs: -Dmaven.test.skip=true # We run the tests on our Jenkins CI


### PR DESCRIPTION
- We run the tests on our own Jenkins CI
- There are some tests which are currently failing on GitHub Actions, however the current shared actions workflow yml has to strict glob patters and don't find the surefire raport XML

e.g:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running workflow.trigger.WebTestCreateNewEmployeeIT
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.368 s -- in workflow.trigger.WebTestCreateNewEmployeeIT
[INFO] Running workflow.businessdata.WebTestBusinessDataIT
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.403 s -- in workflow.businessdata.WebTestBusinessDataIT
[INFO] Running workflow.businessdata.WebTestBusinessCaseDataWorkflowIT
Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.340 s <<< FAILURE! -- in workflow.businessdata.WebTestBusinessCaseDataWorkflowIT
Error:  workflow.businessdata.WebTestBusinessCaseDataWorkflowIT.testInterview -- Time elapsed: 4.337 s <<< FAILURE!
```
and
```
Warning: Could not find any JUnit XML files for */target/*-reports/*.xml, !*/target/*-reports/failsafe-summary.xml
```