### PR TITLE
record jersey standard request logs; including a transaction id

### DIFF
--- a/connectivity/connectivity-demos/config/rest-clients.yaml
+++ b/connectivity/connectivity-demos/config/rest-clients.yaml
@@ -66,6 +66,7 @@ RestClients:
     - ch.ivyteam.ivy.rest.client.authentication.HttpBasicAuthenticationFeature
     - ch.ivyteam.ivy.rest.client.mapper.JsonFeature
     - com.axonivy.connectivity.rest.client.connect.KeepAliveFeature
+    - com.axonivy.connectivity.rest.client.connect.CustomLog
     Properties:
       username: theWorker
       password: ${decrypt:\u007B\u0012\u0012\u0075\u002F\u0017\u00D1\u0083\u00C4\u009C\u0094\u00B0\u009A\u00B2\u00ED\u006B\u0067\u0094\u00D2\u003B\u00BF\u0022\u00F3\u00EC\u00C1\u0014\u00A8\u00D8\u00CB\u009C\u0028\u00F3\u00CB\u0030\u00A7\u0038\u00F0\u0067\u0022\u00C3\u0076\u0016\u0088\u00BC\u0096\u00C9\u00EC\u00BB\u002C\u006E\u005E\u008B\u004A\u00AA\u0082\u0057\u00EF\u000A\u0089\u00E1\u0080\u004E\u0072\u0065}

--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/client/connect/CustomLog.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/client/connect/CustomLog.java
@@ -1,0 +1,27 @@
+package com.axonivy.connectivity.rest.client.connect;
+
+import static ch.ivyteam.ivy.application.RuntimeLogCategory.REST_CLIENT;
+
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+import ch.ivyteam.ivy.application.IProcessModelVersion;
+
+/**
+ * Track sending of requests and receiving of responses using jersey-log capabilities.
+ */
+public class CustomLog implements Feature {
+
+  @Override
+  public boolean configure(FeatureContext context) {
+    var restLog = IProcessModelVersion.current().getRuntimeLog(REST_CLIENT);
+    Logger julLogger = java.util.logging.Logger.getLogger(restLog.getName());
+    @SuppressWarnings({"deprecation", "restriction"})
+    var filter = new org.glassfish.jersey.filter.LoggingFilter(julLogger, true);
+    context.register(filter);
+    return true;
+  }
+
+}


### PR DESCRIPTION
demonstrating the setup of the standard jersey log; would this help in the current customer scenario?
I think the trace-id could be interesting

![jersey-log-filter](https://github.com/user-attachments/assets/fa7ec0c8-27eb-4b03-b512-69458839e00e)
