### PR TITLE
Raise jersey client in test to align with version of platform

### DIFF
--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -8,7 +8,7 @@
 
   <properties>
     <wss4j.version>2.4.1</wss4j.version>
-    <jersey.version>2.31</jersey.version>
+    <jersey.version>2.45</jersey.version>
     <project-build-plugin>10.0.6</project-build-plugin>
   </properties>
 


### PR DESCRIPTION
I've updated jersey. When somebody is using the jersey library in the test project, he will also need to update it. Because it gets mixed with the classpath of the engine.
Something  which was ever since the case, and we are working on it to improve this in future. 

Still some tests are failing, I need to investigate why, But now there are less tests failing. :)